### PR TITLE
aktivierung raus

### DIFF
--- a/de/payment/payment-plugins/klarna.adoc
+++ b/de/payment/payment-plugins/klarna.adoc
@@ -24,11 +24,6 @@ Für die Nutzung von Klarna benötigst du ein link:https://www.klarna.com/de/ver
 
 include::../_textblocks/ausfuehrung-assistent.adoc[]
 
-[.30]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#40]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/lastschrift.adoc
+++ b/de/payment/payment-plugins/lastschrift.adoc
@@ -19,11 +19,6 @@ Die Erklärungen auf dieser Seite finden nach dem Hinzufügen des Plugins Anwend
 
 include::../_textblocks/ausfuehrung-assistent.adoc[]
 
-[#20]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#30]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/mollie.adoc
+++ b/de/payment/payment-plugins/mollie.adoc
@@ -65,11 +65,6 @@ Gehe wie folgt vor, um die Container-Verknüpfungen einzustellen:
 
 |====
 
-[#40]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#50]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/payone.adoc
+++ b/de/payment/payment-plugins/payone.adoc
@@ -167,11 +167,6 @@ Container verknüpfen:
 
 |====
 
-[#50]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#60]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/paypal.adoc
+++ b/de/payment/payment-plugins/paypal.adoc
@@ -159,11 +159,6 @@ Dein plentymarkets System und die PayPal-Schnittstelle kommunizieren über sogen
 
 |====
 
-[#70]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#80]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/sofort.adoc
+++ b/de/payment/payment-plugins/sofort.adoc
@@ -75,11 +75,6 @@ Standard: -
 
 |====
 
-[#30]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#40]
 == Kundenklassen und Versandprofile
 

--- a/de/payment/payment-plugins/vorkasse.adoc
+++ b/de/payment/payment-plugins/vorkasse.adoc
@@ -19,11 +19,6 @@ Die Erklärungen auf dieser Seite finden nach dem Hinzufügen des Plugins Anwend
 
 include::../_textblocks/ausfuehrung-assistent.adoc[]
 
-[#20]
-== Zahlungsart einmalig aktivieren
-
-include::../_textblocks/zahlungsart-aktivieren.adoc[]
-
 [#30]
 == Kundenklassen und Versandprofile
 

--- a/en/payment/payment-plugins/cash-in-advance.adoc
+++ b/en/payment/payment-plugins/cash-in-advance.adoc
@@ -19,11 +19,6 @@ The explanations in this section apply after adding the plugin. You can find mor
 
 include::../_textblocks/completing-assistant.adoc[]
 
-[#20]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#30]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/debit.adoc
+++ b/en/payment/payment-plugins/debit.adoc
@@ -19,11 +19,6 @@ The explanations in this section apply after adding the plugin. You can find mor
 
 include::../_textblocks/completing-assistant.adoc[]
 
-[#20]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#30]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/klarna.adoc
+++ b/en/payment/payment-plugins/klarna.adoc
@@ -24,11 +24,6 @@ To work with Klarna, you first need a link:https://www.klarna.com/uk/business/[K
 
 include::../_textblocks/completing-assistant.adoc[]
 
-[.30]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#40]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/mollie.adoc
+++ b/en/payment/payment-plugins/mollie.adoc
@@ -65,11 +65,6 @@ Proceed as follows to set up container links:
 
 |====
 
-[#40]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#50]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/online-bank-transfer.adoc
+++ b/en/payment/payment-plugins/online-bank-transfer.adoc
@@ -76,11 +76,6 @@ Default: –
 
 |====
 
-[#30]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#40]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/payone.adoc
+++ b/en/payment/payment-plugins/payone.adoc
@@ -167,11 +167,6 @@ Linking template containers:
 
 |====
 
-[#50]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#60]
 == Customer classes and shipping profiles
 

--- a/en/payment/payment-plugins/paypal.adoc
+++ b/en/payment/payment-plugins/paypal.adoc
@@ -159,11 +159,6 @@ Your plentymarkets system and the PayPal interface communicate with the help of 
 
 |====
 
-[#70]
-== Activating the payment method
-
-include::../_textblocks/activate-payment-method.adoc[]
-
 [#80]
 == Customer classes and shipping profiles
 


### PR DESCRIPTION
raus für: Klarna, Lastschrift, Mollie, Payone, PayPal, Sofort und Vorkasse