### PR TITLE
Zahlungsart aktivieren: neu

### DIFF
--- a/de/maerkte/_textblocks/instructions/zahlungsart_aktivieren-neu.adoc
+++ b/de/maerkte/_textblocks/instructions/zahlungsart_aktivieren-neu.adoc
@@ -1,0 +1,8 @@
+Sobald ein aktives Konto für {marketplace} existiert, ist die Zahlungsart *{payment-method}* automatisch im System verfügbar. Es sind keine eigenen Konfigurationen dafür notwendig.
+
+[TIP]
+.Zahlungsart in Kundenklasse erlauben
+====
+Gehe ins Menü *Einrichtung » CRM » Kundenklassen*, um *erlaubte Zahlungsarten* zu aktivieren oder zu deaktivieren. +
+Weitere Informationen findest du im Handbuchkapitel <<payment/zahlungsarten-verwalten#30, Zahlungsart in Kundenklasse erlauben>>.
+====

--- a/de/maerkte/amazon/amazon-einrichten.adoc
+++ b/de/maerkte/amazon/amazon-einrichten.adoc
@@ -412,7 +412,16 @@ include::_textblocks/instructions/rechnungserzeugung.adoc[]
 [#4500]
 == Zahlungsart Amazon aktivieren
 
-include::_textblocks/instructions/amazon-zahlungsart-aktivieren.adoc[]
+Die Zahlungsart *Amazon* ist für Aufträge, die über den Marktplatz Amazon in dein plentymarkets System kommen und nicht zu verwechseln mit der Zahlungsart *Amazon Pay*, die für Kund:innen ist, die über den Marktplatz Amazon in deinem plentyShop einkaufen.
+
+Sobald ein aktives Konto für Amazon existiert, ist die Zahlungsart *Amazon* automatisch im System verfügbar. Es sind keine eigenen Konfigurationen dafür notwendig.
+
+[TIP]
+.Zahlungsart in Kundenklassen erlauben
+====
+Im Menü *Einrichtung » CRM » Kundenklassen* aktivierst oder deaktivierst du *erlaubte Zahlungsarten*. +
+Weitere Informationen findest du auf der Handbuchseite <<payment/zahlungsarten-verwalten#30, Zahlungsart in Kundenklasse erlauben>>.
+====
 
 [#6600]
 == API-Log abrufen

--- a/de/maerkte/bol-com.adoc
+++ b/de/maerkte/bol-com.adoc
@@ -367,10 +367,10 @@ a| Die Variante muss für den Marktplatz verfügbar sein.
 [#650]
 == Zahlungsart aktivieren
 
+:marketplace: bol.com
 :payment-method: Bol.com
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#700]
 == Versandbestätigungen automatisch senden

--- a/de/maerkte/cdiscount.adoc
+++ b/de/maerkte/cdiscount.adoc
@@ -269,10 +269,10 @@ Hersteller verknüpfen:
 [#900]
 == Zahlungsart aktivieren
 
+:marketplace: Cdiscount
 :payment-method: Cdiscount
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 
 [#950]
@@ -352,10 +352,6 @@ a|
 * *Preise und Bestände aktualisieren und Auftragsimport aktivieren* ist aktiviert.
 * *API-Benutzername* ist eingegebenen.
 * *API-Passwort* ist eingegebenen.
-
-| Zahlungsarten
-a|
-*  Die *Zahlungsart Cdiscount* ist aktiviert.
 
 | Einstellungen der Variante
 a|

--- a/de/maerkte/check24.adoc
+++ b/de/maerkte/check24.adoc
@@ -77,10 +77,10 @@ include::_textblocks/instructions/verkaufspreis-festlegen.adoc[]
 [#700]
 == Zahlungsart aktivieren
 
+:marketplace: check24
 :payment-method: check24
-:folder: DE
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 
 [#500]

--- a/de/maerkte/ebay/ebay-einrichten.adoc
+++ b/de/maerkte/ebay/ebay-einrichten.adoc
@@ -843,7 +843,7 @@ Profil erstellen:
 | Eine oder mehrere Zahlungsarten wählen.
 
 | *PayPal-Konto*
-| PayPal-Konto wählen. Es werden nur PayPal-Konten angezeigt, die unter *Einrichtung » Aufträge » Zahlung » Zahlungsarten » PayPal* eingerichtet wurden.
+| PayPal-Konto wählen. Es werden nur bereits <<payment/payment-plugins/paypal#, eingerichtete PayPal-Konten>> angezeigt.
 
 | *Sofortige Bezahlung*
 | Aktivieren, um PayPal als einzige Zahlungsart zu erlauben. +
@@ -1054,10 +1054,10 @@ a| Aktivieren, um den Käuferkreis einzuschränken. +
 
 Die Zahlungsart eBay-Rechnungskauf ist für eine Preisspanne von 1,50 EUR bis 1,500 EUR möglich und gilt für alle Kategorien außer für digitale Güter. Um eBay-Rechnungskauf nutzen zu können, muss der Artikel mit PayPal bezahlbar sein.
 
+:marketplace: eBay
 :payment-method: eBay-Rechnungskauf
-:folder: DE
 
-include::../_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#2300]
 == Listings vorbereiten

--- a/de/maerkte/flubit.adoc
+++ b/de/maerkte/flubit.adoc
@@ -120,10 +120,10 @@ include::_textblocks/instructions/verkaufspreis-festlegen.adoc[]
 [#370]
 == Zahlungsart aktivieren
 
+:marketplace: Flubit
 :payment-method: Flubit
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#400]
 == Versandbestätigungen automatisch senden

--- a/de/maerkte/fruugo.adoc
+++ b/de/maerkte/fruugo.adoc
@@ -133,10 +133,10 @@ Fruugo benötigt von allen Händler:innen eine Liste der Versandkosten. Diese Li
 [#600]
 == Zahlungsart aktivieren
 
+:marketplace: Fruugo
 :payment-method: Fruugo
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#700]
 == Auftragsbestätigungen automatisch senden

--- a/de/maerkte/idealo/idealo-einrichten.adoc
+++ b/de/maerkte/idealo/idealo-einrichten.adoc
@@ -270,7 +270,6 @@ Je nachdem, ob du nur den idealo Preisvergleich nutzen möchtest oder deinen Kun
 - *Variantenverfügbarkeit:* Aktiviere im Menü *Artikel » Artikel bearbeiten » [Artikel öffnen] » [Variante öffnen] » Varianten-Tab: Verfügbarkeit* im Bereich *Märkte* zusätzlich zur Option *idealo* auch die <<#500, Verfügbarkeit>> *idealo Direktkauf*.
 - *Verkaufspreis:* Richte einen <<#600, Verkaufspreis>> ein.
 - *SKU:* Füge marktplatzspezifische <<#700, SKUs>> hinzu, wenn gewünscht.
-- *Zahlungsart:* Richte die <<#1100, Zahlungsart>> *idealo Direktkauf* ein.
 - *Merkmale:* Erstelle <<#1200, Merkmale>> für idealo Direktkauf. Mit Merkmalen überträgst du Artikeleigenschaften, Versandarten und Gebühren an idealo Direktkauf.
 - *Ereignisaktionen:* Richte <<#1600, Ereignisaktionen>> ein, um Änderungen am Auftragsstatus automatisch an idealo Direktkauf zu senden.
 
@@ -643,23 +642,15 @@ Es werden die Zahlungsarten gemäß der Formateinstellung *Versandkosten* in ein
 [#1100]
 == Zahlungsart idealo Direktkauf aktivieren
 
-Damit Zahlungen für Aufträge von idealo Direktkauf durchgeführt und in deinem plentymarkets System angezeigt werden, aktiviere die Zahlungsart *idealo Direktkauf*.
-
-[TIP]
-.Zahlungsart nur für idealo Direktkauf
-====
-Die Zahlungsart *idealo Direktkauf* muss nur aktiviert werden, wenn du idealo Direktkauf nutzt.
-====
-
+:marketplace: idealo
 :payment-method: idealo Direktkauf
-:folder: DE
 
-include::../_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [IMPORTANT]
 .Zahlungsart PayPal
 ====
-Wenn du PayPal als Zahlungsart anbietest, muss die Zahlungsart PayPal zwingend in deinem plentymarkets System gespeichert und eingerichtet sein, damit die Zahlung korrekt importiert und dem Auftrag zugeordnet werden kann.
+Wenn du PayPal als Zahlungsart anbietest, muss die Zahlungsart <<payment/payment-plugins/paypal#, PayPal>> zwingend in deinem plentymarkets System gespeichert und eingerichtet sein, damit die Zahlung korrekt importiert und dem Auftrag zugeordnet werden kann.
 ====
 
 [#1200]

--- a/de/maerkte/kaufland-de/kaufland-de-einrichten.adoc
+++ b/de/maerkte/kaufland-de/kaufland-de-einrichten.adoc
@@ -306,12 +306,10 @@ Es kann vorkommen, dass deine Unterkategorien nicht mit denen von Kaufland.de ü
 [#800]
 == Zahlungsart aktivieren
 
+:marketplace: Kaufland.de
 :payment-method: real.de Payment
-:folder: DE
-:real-client:
-:real-name:
 
-include::../_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#850]
 == Rechnungsdokument bearbeiten

--- a/de/maerkte/neckermann/neckermann-at-einrichten.adoc
+++ b/de/maerkte/neckermann/neckermann-at-einrichten.adoc
@@ -616,10 +616,10 @@ Merkmal Produktdatenblatt mit Artikel verknüpfen:
 [#1600]
 == Zahlungsart aktivieren
 
+:marketplace: Neckermann.at
 :payment-method: Neckermann Payment
-:folder: International
 
-include::../_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#1350]
 == PDF-Vorlage für Lieferscheine hochladen

--- a/de/maerkte/otto/otto-market.adoc
+++ b/de/maerkte/otto/otto-market.adoc
@@ -183,10 +183,10 @@ include::../_textblocks/instructions/verkaufspreis-festlegen.adoc[]
 [#425]
 == Zahlungsart aktivieren
 
+:marketplace: OTTO Market
 :payment-method: Otto Payment
-:folder: International
 
-include::../_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#450]
 == Artikelexport einrichten

--- a/de/maerkte/pixmania.adoc
+++ b/de/maerkte/pixmania.adoc
@@ -303,10 +303,10 @@ include::_textblocks/instructions/link-attributes.adoc[]
 [#800]
 ==  Zahlungsart aktivieren
 
+:marketplace: PIXmania
 :payment-method: PIXmania Payment
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#900]
 == Exportverlauf abrufen

--- a/de/maerkte/plus-gartenxxl.adoc
+++ b/de/maerkte/plus-gartenxxl.adoc
@@ -213,10 +213,10 @@ TIP: Als Alternative kannst du ein Merkmal für die Grundpreispflicht erstellen.
 [#400]
 == Zahlungsart aktivieren
 
+:marketplace: Netto Marken-Discount
 :payment-method: Netto
-:folder: DE
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#500]
 == Kategorien verknüpfen

--- a/de/maerkte/shopgate.adoc
+++ b/de/maerkte/shopgate.adoc
@@ -233,10 +233,10 @@ include::_textblocks/instructions/activate-characteristic.adoc[]
 [#600]
 == Zahlungsart aktivieren
 
+:marketplace: Shopgate
 :payment-method: Shopgate Payment
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [IMPORTANT]
 .Zahlungsart Amazon Pay

--- a/de/maerkte/yatego.adoc
+++ b/de/maerkte/yatego.adoc
@@ -258,10 +258,10 @@ Die Versandbestätigung wird nicht automatisch an Yatego gesendet. Der Auftrag m
 [#900]
 == Zahlungsart aktivieren
 
+:marketplace: Yatego
 :payment-method: Yatego Rechnung
-:folder: DE
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#1000]
 == API-Log abrufen

--- a/de/maerkte/zalando.adoc
+++ b/de/maerkte/zalando.adoc
@@ -429,10 +429,10 @@ include::_textblocks/instructions/link-attributes.adoc[]
 [#800]
 == Zahlungsart aktivieren
 
+:marketplace: Zalando
 :payment-method: Zalando Payment
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::../_textblocks/instructions/zahlungsart_aktivieren-neu.adoc[]
 
 [#1100]
 == _Checkliste_ für den Variantenexport

--- a/en/markets/_textblocks/instructions/activate-payment-method_new.adoc
+++ b/en/markets/_textblocks/instructions/activate-payment-method_new.adoc
@@ -1,0 +1,8 @@
+As soon as an active account for {market} exists, the payment method *{payment-method}* is automatically available in your plentymarkets system. No separate configurations are needed for this.
+
+[TIP]
+.Permitting the payment method in customer classes
+====
+Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
+For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> chapter.
+====

--- a/en/markets/amazon/amazon-setup.adoc
+++ b/en/markets/amazon/amazon-setup.adoc
@@ -409,7 +409,16 @@ include::_textblocks/instructions/invoice-creation.adoc[]
 [#4500]
 == Activating the Amazon payment method
 
-include::_textblocks/instructions/amz-payment-method.adoc[]
+The *Amazon* payment method is used for orders that were placed on Amazon and transferred to your plentymarkets system. Do not confuse this with *Amazon Pay*, which is a way for customers to use the Amazon checkout process when placing orders in your plentyShop.
+
+As soon as an active Amazon account exists, the payment method is automatically available in your plentymarkets system. No separate configurations are needed for this.
+
+[TIP]
+.Permitting the payment method in customer classes
+====
+Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
+For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> page of the manual.
+====
 
 [#6600]
 == Viewing the API log

--- a/en/markets/bol-com.adoc
+++ b/en/markets/bol-com.adoc
@@ -367,10 +367,10 @@ a| The variation must be available for the market.
 [#650]
 == Activating the payment method
 
+:market: bol.com
 :payment-method: Bol.com
-:folder: International
 
-include::_textblocks/instructions/activate-payment-method.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#700]
 == Automatically sending shipping confirmations

--- a/en/markets/cdiscount.adoc
+++ b/en/markets/cdiscount.adoc
@@ -307,72 +307,10 @@ Linking manufacturers:
 [#900]
 == Activating the payment method
 
-Activate the <<payment/managing-payment-methods#, payment method>> *Cdiscount* as described below.
+:market: Cdiscount
+:payment-method: Cdiscount
 
-[.instruction]
-Activating the Cdiscount payment method:
-
-. Go to *Setup » Orders » Payment » Methods*.
-. Activate the option *Also show inactive*.
-. Open the folder *International*.
-. Click on *Cdiscount*. +
-→ The *Settings* tab opens.
-. Carry out the settings. Pay attention to the explanations given in <<#settings-payment-method-cdiscount>>.
-. Place a check mark next to the option *Active*.
-. *Save* (icon:save[role="green"]) the settings.
-
-[[settings-payment-method-cdiscount]]
-.Settings for the payment method
-[cols="1,3a"]
-|====
-| Setting | Explanation
-
-| *Language*
-| The following options are saved for the language selected: *Name*, *Info page*, *Info page (internal)*, *Logo*, and *Upload logo*. This enables you to enter values for these options in various languages. The values for a language are activated as soon as a buyer selects the language in the plentyShop.
-
-| *Name*
-| Enter the name that should be displayed in the plentyShop and on invoices etc.
-
-| *Info page*
-| Select a category page of the type *content* or enter the URL of a website to provide information about the payment method.
-
-| *Info page (external)*
-| If you selected the *Info page (external)* option under *Info page*, then enter the URL of the info page here.
-
-| *Countries of delivery*
-| Do not select a country of delivery. +
-You cannot use the payment method in your plentyShop. Therefore, this payment method is only activated in plentymarkets. It is not completely set up.
-
-| *Logo*
-a| Select one of the following options for displaying the logo: +
-
-* *Show standard logo* = The logo that is saved in plentymarkets for this payment method is displayed. +
-* *Do not show a logo* = The logo that is saved in plentymarkets for this payment method is not displayed. +
-* *Show upload logo* = The options *Logo view* and *Upload logo* are displayed.
-
-| *Logo view*
-| If *Show upload logo* was selected from the *Logo* drop-down list, then the logo that was uploaded is displayed here.
-
-| *Upload logo*
-| If *Show upload logo* was selected from the *Logo* drop-down list, then upload an external logo here. +
-Click on *Upload files* and select the logo that you want to upload for the payment method. Permitted data formats: GIF, PNG, and JPG.
-
-| *Priority*
-| Select the priority for displaying the payment method in the plentyShop.
-
-| *Costs: Flat rate or percentage*
-| If the payment method results in additional costs, enter the percentage value or flat rate value. The selection depends on the conditions of your contract. *_Important:_* Do not enter a value into both fields. +
-For further information, refer to the <<business-decisions/plenty-bi/statistics#, Managing statistics>> page. For an example of flat rate and percentage costs, refer to the <<payment/managing-payment-methods#20, Managing payment methods>> page.
-|====
-
-[TIP]
-.Permitting the payment method in customer classes
-====
-Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
-For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> chapter.
-====
-
-For further information, refer to the <<payment/managing-payment-methods#, Managing payment methods>> page.
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#950]
 == Setting up the data exchange
@@ -451,10 +389,6 @@ a|
 * *Update prices and stock and activate order import* is activated.
 * *API user name* is entered.
 * *API password* is entered.
-
-| Payment methods
-a|
-*  The *payment method Cdiscount* is activated.
 
 | Variation settings
 a|

--- a/en/markets/check24.adoc
+++ b/en/markets/check24.adoc
@@ -77,10 +77,10 @@ include::_textblocks/instructions/define-sales-price.adoc[]
 [#700]
 == Activating the payment method
 
-:payment-method: check24
-:folder: DE
+:market: check 24
+:payment-method: check 24
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 
 [#500]

--- a/en/markets/ebay/ebay-setup.adoc
+++ b/en/markets/ebay/ebay-setup.adoc
@@ -843,7 +843,7 @@ Creating a new profile:
 | Select one or several payment methods.
 
 | *PayPal account*
-| Select a PayPal account. You will only see those PayPal accounts that were set up in the *Setup » Orders » Payment » Payment methods » PayPal* menu.
+| Select a PayPal account. You will only see those <<payment/payment-plugins/paypal#, PayPal accounts>> that were already set up.
 
 | *Immediate payment*
 | Activate in order to allow PayPal as the only payment method. +
@@ -1054,10 +1054,10 @@ a| Activate to exclude certain customers. +
 
 The payment method eBay purchase on invoice is appropriate for items within the price range of 1.50 € - 1.500 €. In order to use eBay purchase on invoice the item must be paid for by PayPal.
 
+:market: eBay
 :payment-method: eBay purchase on invoice
-:folder: DE
 
-include::../_textblocks/instructions/activate-payment-method.adoc[]
+include::../_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#2300]
 == Preparing listings

--- a/en/markets/flubit.adoc
+++ b/en/markets/flubit.adoc
@@ -120,10 +120,10 @@ include::_textblocks/instructions/define-sales-price.adoc[]
 [#370]
 == Activating the payment method
 
+:market: Flubit
 :payment-method: Flubit
-:folder: International
 
-include::_textblocks/instructions/activate-payment-method.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#400]
 == Automatically sending shipping confirmations

--- a/en/markets/fruugo.adoc
+++ b/en/markets/fruugo.adoc
@@ -150,70 +150,10 @@ Fruugo requires a list of shipping costs from each seller. This list cannot be t
 [#600]
 == Activating the payment method
 
-Activate the <<payment/managing-payment-methods#, payment method>> *Fruugo* as described below.
+:market: Fruugo
+:payment-method: Fruugo
 
-[.instruction]
-Activating the Fruugo payment method:
-
-. Go to *Setup » Orders » Payment » Methods*.
-. Click on the folder *International > Fruugo*.  +
-→ The settings for the Fruugo payment method are displayed.
-. Carry out the settings. Pay attention to the explanations given in <<#settings-payment-method-fruugo>>.
-. Place a check mark next to the option *Active*.
-. *Save* (icon:save[role="green"]) the settings.
-
-[[settings-payment-method-fruugo]]
-.Settings for the payment method
-[cols="1,3a"]
-|====
-|Setting |Explanation
-
-| *Language*
-|The following options are saved for the language selected: *Name*, *Info page*, *Info page (internal)*, *Logo*, and *Upload logo*. This enables you to enter values for these options in various languages. The values for a language are activated as soon as a buyer selects the language in the plentyShop.
-
-| *Name*
-|Enter the name that should be displayed in the plentyShop and on invoices etc.
-
-| *Info page*
-|Select a category page of the type *content* or enter the URL of a website to provide information about the payment method.
-
-| *Info page (external)*
-|If you selected the *Info page (external)* option under *Info page*, then enter the URL of the info page here.
-
-| *Countries of delivery*
-|Do not select a country of delivery. +
-You cannot use the payment method in your plentyShop. Therefore, this payment method is only activated in plentymarkets. It is not completely set up.
-
-| *Logo*
-a|Select one of the following options for displaying the logo: +
-
-* *Show standard logo* = The logo that is saved in plentymarkets for this payment method is displayed. +
-* *Do not show a logo* = The logo that is saved in plentymarkets for this payment method is not displayed. +
-* *Show upload logo* = The options *Logo view* and *Upload logo* are displayed.
-
-| *Logo view*
-|If *Show upload logo* was selected from the *Logo* drop-down list, then the logo that was uploaded is displayed here.
-
-| *Upload logo*
-|If *Show upload logo* was selected from the *Logo* drop-down list, then upload an external logo here. +
-Click on *Upload files* and select the logo that you want to upload for the payment method. Permitted data formats: GIF, PNG, and JPG.
-
-| *Priority*
-|Select the priority for displaying the payment method in the plentyShop.
-
-| *Costs: Flat rate or percentage*
-|If the payment method results in additional costs, enter the percentage value or flat rate value. The selection depends on the conditions of your contract. *_Important:_* Do not enter a value into both fields.  +
-For further information, refer to the <<business-decisions/plenty-bi/statistics#, Managing statistics>> page. For an example of flat rate and percentage costs, refer to the <<payment/managing-payment-methods#20, Managing payment methods>> page.
-|====
-
-[TIP]
-.Permitting the payment method in customer classes
-====
-Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
-For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> chapter.
-====
-
-For further information, refer to the <<payment/managing-payment-methods#, Managing payment methods>> page.
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#700]
 == Automatically sending order confirmations

--- a/en/markets/idealo-checkout/idealo-setup.adoc
+++ b/en/markets/idealo-checkout/idealo-setup.adoc
@@ -270,7 +270,6 @@ Depending on whether you only want to use the idealo price comparison or whether
 - *Variation availability:* In addition to the order referrer *idealo*, also activate the <<#500, order referrer>> *idealo Checkout* in the *Markets* area of the *Item » Edit item » [Open item] » [Open variation] » Tab: Availability* menu.
 - *Sales price:* Set up a <<#600, sales price>>.
 - *SKU:* Add <<#700, SKUs>> if needed.
-- *Payment method:* Activate the <<#1100, payment method>> *idealo Checkout*.
 - *Characteristics:* Create <<#1200, characteristics>> for idealo Checkout. Item characteristics, shipping methods and fees are transferred to idealo Checkout with characteristics.
 - *Event procedures:* Set up <<#1600, event procedures>> to automatically inform idealo about changes in the order status.
 
@@ -643,23 +642,15 @@ All payment methods will be exported, according to the format setting *Shipping 
 [#1100]
 == Activating the payment method idealo Checkout
 
-Activate the payment method *idealo Checkout*. This allows payments to be made for orders on idealo and to be displayed in your plentymarkets system.
-
-[TIP]
-.Payment method for idealo Checkout only
-====
-You only have to activate the payment method *idealo Checkout* if you use idealo Checkout.
-====
-
+:market: idealo
 :payment-method: idealo Checkout
-:folder: DE
 
-include::../_textblocks/instructions/activate-payment-method.adoc[]
+include::../_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [IMPORTANT]
 .PayPal payment method
 ====
-If you offer the PayPal payment method, it is mandatory to create and configure this payment method in your plentymarkets system. This is to ensure that the payment is imported and assigned to the order correctly.
+If you offer PayPal as a payment method, it is mandatory to create and configure <<payment/payment-plugins/paypal#, PayPal>> in your plentymarkets system first. This is to ensure that the payment is imported and assigned to the order correctly.
 ====
 
 [#1200]

--- a/en/markets/kaufland-de/kaufland-setup.adoc
+++ b/en/markets/kaufland-de/kaufland-setup.adoc
@@ -306,12 +306,10 @@ In some cases, your subcategories may not match the Kaufland.de subcategories. I
 [#800]
 == Activating the payment method
 
+:market: Kaufland.de
 :payment-method: real.de Payment
-:folder: DE
-:real-client:
-:real-name:
 
-include::../_textblocks/instructions/activate-payment-method.adoc[]
+include::../_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#850]
 == Editing the invoice

--- a/en/markets/neckermann/neckermann-at-setup.adoc
+++ b/en/markets/neckermann/neckermann-at-setup.adoc
@@ -616,10 +616,10 @@ Linking product data sheet characteristic to an item:
 [#1600]
 == Activating the payment method
 
+:market: Neckermann.at
 :payment-method: Neckermann Payment
-:folder: International
 
-include::../_textblocks/instructions/activate-payment-method.adoc[]
+include::../_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#1350]
 == Uploading a PDF template for delivery notes

--- a/en/markets/otto/otto-market.adoc
+++ b/en/markets/otto/otto-market.adoc
@@ -183,10 +183,10 @@ include::../_textblocks/instructions/define-sales-price.adoc[]
 [#425]
 == Activating the payment method
 
+:market: OTTO Market
 :payment-method: Otto Payment
-:folder: International
 
-include::../_textblocks/instructions/activate-payment-method.adoc[]
+include::../_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#450]
 == Setting up the item export

--- a/en/markets/pixmania.adoc
+++ b/en/markets/pixmania.adoc
@@ -320,72 +320,10 @@ include::_textblocks/instructions/link-attributes.adoc[]
 [#800]
 ==  Activating the payment method
 
-Activate the <<payment/managing-payment-methods#, payment method>> *PIXmania Payment* as described below.
+:market: PIXmania
+:payment-method: PIXmania Payment
 
-[.instruction]
-Activating the PIXmania payment method:
-
-. Go to *Setup » Orders » Payment » Methods*.
-. Activate the option *Also show inactive*.
-. Open the folder *International*.
-. Click on *PIXmania Payment*. +
-→ The *Settings* tab opens.
-. Carry out the settings. Pay attention to the explanations given in <<#settings-payment-method-pixmania>>.
-. Place a check mark next to the option *Active*.
-. *Save* (icon:save[role="green"]) the settings.
-
-[[settings-payment-method-pixmania]]
-.Settings for the payment method
-[cols="1,3a"]
-|====
-| Setting | Explanation
-
-| *Language*
-| The following options are saved for the language selected: *Name*, *Info page*, *Info page (internal)*, *Logo*, and *Upload logo*. This enables you to enter values for these options in various languages. The values for a language are activated as soon as a buyer selects the language in the plentyShop.
-
-| *Name*
-| Enter the name that should be displayed in the plentyShop and on invoices etc.
-
-| *Info page*
-| Select a category page of the type *content* or enter the URL of a website to provide information about the payment method.
-
-| *Info page (external)*
-| If you selected the *Info page (external)* option under *Info page*, then enter the URL of the info page here.
-
-| *Countries of delivery*
-| Do not select a country of delivery. +
-You cannot use the payment method in your plentyShop. Therefore, this payment method is only activated in plentymarkets. It is not completely set up.
-
-| *Logo*
-a| Select one of the following options for displaying the logo: +
-
-* *Show standard logo* = The logo that is saved in plentymarkets for this payment method is displayed. +
-* *Do not show a logo* = The logo that is saved in plentymarkets for this payment method is not displayed. +
-* *Show upload logo* = The options *Logo view* and *Upload logo* are displayed.
-
-| *Logo view*
-| If *Show upload logo* was selected from the *Logo* drop-down list, then the logo that was uploaded is displayed here.
-
-| *Upload logo*
-| If *Show upload logo* was selected from the *Logo* drop-down list, then upload an external logo here. +
-Click on *Upload files* and select the logo that you want to upload for the payment method. Permitted data formats: GIF, PNG, and JPG.
-
-| *Priority*
-| Select the priority for displaying the payment method in the plentyShop.
-
-| *Costs: Flat rate or percentage*
-| If the payment method results in additional costs, enter the percentage value or flat rate value. The selection depends on the conditions of your contract. *_Important:_* Do not enter a value into both fields. +
-For further information, refer to the <<business-decisions/plenty-bi/statistics#, Statistics>> page of the manual. For an example of flat rate and percentage costs, refer to the <<payment/managing-payment-methods#20, Managing payment methods>> page.
-|====
-
-[TIP]
-.Permitting the payment method in customer classes
-====
-Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
-For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> chapter.
-====
-
-For further information, refer to the <<payment/managing-payment-methods#, Managing payment methods>> page.
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#900]
 == Viewing the export history

--- a/en/markets/plus-gartenxxl.adoc
+++ b/en/markets/plus-gartenxxl.adoc
@@ -213,10 +213,10 @@ TIP: As an alternative, you can create a characteristic for mandatory unit price
 [#400]
 == Activating the payment method
 
+:market: Netto
 :payment-method: Netto
-:folder: DE
 
-include::_textblocks/instructions/activate-payment-method.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#500]
 == Linking categories

--- a/en/markets/shopgate.adoc
+++ b/en/markets/shopgate.adoc
@@ -267,72 +267,10 @@ Linking properties:
 [#600]
 == Activating the payment method
 
-Activate the <<payment/managing-payment-methods#, payment method>> *Shopgate Payment* as described below.
+:market: Shopgate
+:payment-method: Shopgate Payment
 
-[.instruction]
-Activating the Shopgate payment method:
-
-. Go to *Setup » Orders » Payment » Methods*.
-. Activate the option *Also show inactive*.
-. Open the folder *International*.
-. Click on *Shopgate Payment*. +
-→ The *Settings* tab opens.
-. Carry out the settings. Pay attention to the explanations given in <<#settings-payment-method-shopgate>>.
-. Place a check mark next to the option *Active*.
-. *Save* (icon:save[role="green"]) the settings.
-
-[[settings-payment-method-shopgate]]
-.Settings for the payment method
-[cols="1,3a"]
-|====
-| Setting | Explanation
-
-| *Language*
-|The following options are saved for the language selected: *Name*, *Info page*, *Info page (internal)*, *Logo* and *Upload logo*. This enables you to enter values for these options in various languages. The values for a language are activated as soon as a buyer selects the language in the plentyShop.
-
-| *Name*
-|Enter the name that should be displayed in the plentyShop and on invoices etc.
-
-| *Info page*
-|Select a category page of the type *content* or enter the URL of a website to provide information about the payment method.
-
-| *Info page (external)*
-|If you selected the *Info page (external)* option under *Info page*, then enter the URL of the info page here.
-
-| *Countries of delivery*
-|Do not select a country of delivery. +
-You cannot use the payment method in your plentyShop. Therefore, this payment method is only activated in plentymarkets. It is not completely set up.
-
-| *Logo*
-a|Select one of the following options for displaying the logo: +
-
-* *Show standard logo* = The logo that is saved in plentymarkets for this payment method is displayed. +
-* *Do not show a logo* = The logo that is saved in plentymarkets for this payment method is not displayed. +
-* *Show upload logo* = The options *Logo view* and *Upload logo* are displayed.
-
-| *Logo view*
-|If *Show upload logo* was selected from the *Logo* drop-down list, then the logo that was uploaded is displayed here.
-
-| *Upload logo*
-|If *Show upload logo* was selected from the *Logo* drop-down list, then upload an external logo here. +
-Click on *Upload files* and select the logo that you want to upload for the payment method. Permitted data formats: GIF, PNG, and JPG.
-
-| *Priority*
-|Select the priority for displaying the payment method in the plentyShop.
-
-| *Costs: Flat rate or percentage*
-|If the payment method results in additional costs, enter the percentage value or flat rate value. The selection depends on the conditions of your contract. *_Important:_* Do not enter a value into both fields. +
-For further information, refer to the <<business-decisions/plenty-bi/statistics#, Managing statistics>> page. For an example of flat rate and percentage costs, refer to the <<payment/managing-payment-methods#20, Managing payment methods>> page.
-|====
-
-[TIP]
-.Permitting the payment method in customer classes
-====
-Go to *Setup » CRM » Classes* to activate or deactivate *permitted payment methods*. +
-For further information, refer to the <<payment/managing-payment-methods#30, Permitting the payment method in a customer class>> chapter.
-====
-
-For further information, refer to the <<payment/managing-payment-methods#, Managing payment methods>> page.
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [IMPORTANT]
 .Amazon Pay payment method

--- a/en/markets/yatego.adoc
+++ b/en/markets/yatego.adoc
@@ -258,10 +258,10 @@ The shipping confirmation is not sent to Yatego automatically. The order must be
 [#900]
 == Activating the payment method
 
+:market: Yatego
 :payment-method: Yatego invoice
-:folder: DE
 
-include::_textblocks/instructions/activate-payment-method.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#1000]
 == Viewing the API log

--- a/en/markets/zalando.adoc
+++ b/en/markets/zalando.adoc
@@ -429,10 +429,10 @@ include::_textblocks/instructions/link-attributes.adoc[]
 [#800]
 == Activating the payment method
 
+:market: Zalando
 :payment-method: Zalando Payment
-:folder: International
 
-include::_textblocks/instructions/zahlungsart_aktivieren.adoc[]
+include::_textblocks/instructions/activate-payment-method_new.adoc[]
 
 [#1100]
 == _Check list_ for exporting variations


### PR DESCRIPTION
- neue Include-Datei für de und en
- eingefügt auf allen Marktplätzen, auf denen payment methods vorher extra aktiviert werden mussten